### PR TITLE
Allow retrieval of non-UTF8 data from terminal

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,9 +24,11 @@ export interface IPtyForkOptions {
   env?: ProcessEnv;
   uid?: number;
   gid?: number;
+  encoding?: string;
 }
 
 export interface IPtyOpenOptions {
   cols?: number;
   rows?: number;
+  encoding?: string;
 }

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -60,6 +60,8 @@ export class UnixTerminal extends Terminal {
     env.TERM = name;
     const parsedEnv = this._parseEnv(env);
 
+    const encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
+
     const onexit = (code: any, signal: any) => {
       // XXX Sometimes a data event is emitted after exit. Wait til socket is
       // destroyed.
@@ -73,10 +75,12 @@ export class UnixTerminal extends Terminal {
     };
 
     // fork
-    const term = pty.fork(file, args, parsedEnv, cwd, cols, rows, uid, gid, onexit);
+    const term = pty.fork(file, args, parsedEnv, cwd, cols, rows, uid, gid, (encoding === 'utf8'), onexit);
 
     this.socket = new PipeSocket(term.fd);
-    this.socket.setEncoding('utf8');
+    if (encoding !== null) {
+      this.socket.setEncoding(encoding);
+    }
     this.socket.resume();
 
     // setup
@@ -149,16 +153,21 @@ export class UnixTerminal extends Terminal {
 
     const cols = opt.cols || Terminal.DEFAULT_COLS;
     const rows = opt.rows || Terminal.DEFAULT_ROWS;
+    const encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
 
     // open
     const term = pty.open(cols, rows);
 
     self.master = new PipeSocket(term.master);
-    self.master.setEncoding('utf8');
+    if (encoding !== null) {
+      self.master.setEncoding(encoding);
+    }
     self.master.resume();
 
     self.slave = new PipeSocket(term.slave);
-    self.slave.setEncoding('utf8');
+    if (encoding !== null) {
+      self.slave.setEncoding(encoding);
+    }
     self.slave.resume();
 
     self.socket = self.master;


### PR DESCRIPTION
Hi there,

we're evaluating node-pty for running a very old application. This application unfortunately doesn't know anything about UTF-8 and produces all output in a local character set (ISO-8859-15). In order to be able to retrieve the output without characters > x7F being turned into substitution characters (uFFDD) it's necessary to modify node-pty so that a Buffer (instead of a string) is passed into the 'data' event callback.

This patch is a first attempt at making that happen. It only considers Linux/Unix. On Windows, these shenanigans should not be necessary if I'm informed correctly.

Thank you for looking into this and in general for working on this awesome piece of software.