### PR TITLE
Fix link to VS Code homepage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is useful for:
 
 `node-pty` powers many different terminal emulators, including:
 
-- [Microsoft Visual Studio Code](code.visualstudio.com)
+- [Microsoft Visual Studio Code](https://code.visualstudio.com)
 - [Hyper](https://hyper.is/)
 - [Upterm](https://github.com/railsware/upterm)
 - [Script Runner](https://github.com/ioquatix/script-runner) for Atom.


### PR DESCRIPTION
Points to https://github.com/Tyriar/node-pty/blob/master/code.visualstudio.com at the moment.