### PR TITLE
Changed unix version of .kill function to send signals to all processes

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -358,7 +358,9 @@ NAN_METHOD(PtyOpen) {
 NAN_METHOD(PtyKill) {
   Nan::HandleScope scope;
 
-  if (info.Length() != 2 || !info[0]->IsNumber()) {
+  if (info.Length() != 2 ||
+      !info[0]->IsNumber() ||
+      !info[1]->IsNumber()) {
     return Nan::ThrowError("Usage: pty.kill(fd, signal)");
   }
 

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -235,6 +235,8 @@ export class UnixTerminal extends Terminal {
     signal = signal || 'SIGHUP';
     if (signal in os.constants.signals) {
       try {
+        // pty.kill will not be available on systems which don't support
+        // the TIOCSIG/TIOCSIGNAL ioctl
         if (pty.kill && signal !== 'SIGHUP') {
           pty.kill(this._fd, os.constants.signals[signal]);
         } else {
@@ -242,7 +244,7 @@ export class UnixTerminal extends Terminal {
         }
       } catch (e) { /* swallow */ }
     } else {
-      // Unknown signal
+      throw new Error('Unknown signal: ' + signal);
     }
   }
 

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -233,13 +233,13 @@ export class UnixTerminal extends Terminal {
 
   public kill(signal?: string): void {
     signal = signal || 'SIGHUP';
-    if (signal === 'SIGHUP') {
+    if (signal in os.constants.signals) {
       try {
-        process.kill(this.pid, 'SIGHUP');
-      } catch (e) { /* swallow */ }
-    } else if (signal in os.constants.signals) {
-      try {
-        pty.kill(this._fd, os.constants.signals[signal]);
+        if (pty.kill && signal !== 'SIGHUP') {
+          pty.kill(this._fd, os.constants.signals[signal]);
+        } else {
+          process.kill(this.pid, signal);
+        }
       } catch (e) { /* swallow */ }
     } else {
       // Unknown signal

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -6,6 +6,7 @@
 import * as net from 'net';
 import * as path from 'path';
 import * as tty from 'tty';
+import * as os from 'os';
 import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
 import { ProcessEnv, IPtyForkOptions, IPtyOpenOptions } from './interfaces';
 import { ArgvOrCommandLine } from './types';
@@ -231,9 +232,18 @@ export class UnixTerminal extends Terminal {
   }
 
   public kill(signal?: string): void {
-    try {
-      process.kill(this.pid, signal || 'SIGHUP');
-    } catch (e) { /* swallow */ }
+    signal = signal || 'SIGHUP';
+    if (signal == 'SIGHUP') {
+      try {
+        process.kill(this.pid, 'SIGHUP');
+      } catch (e) { /* swallow */ }
+    }else if(signal in os.constants.signals){
+      try {
+        pty.kill(this._fd, os.constants.signals[signal]);
+      } catch (e) { /* swallow */ }
+    }else{
+      // Unknown signal
+    }
   }
 
   /**

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -233,15 +233,15 @@ export class UnixTerminal extends Terminal {
 
   public kill(signal?: string): void {
     signal = signal || 'SIGHUP';
-    if (signal == 'SIGHUP') {
+    if (signal === 'SIGHUP') {
       try {
         process.kill(this.pid, 'SIGHUP');
       } catch (e) { /* swallow */ }
-    }else if(signal in os.constants.signals){
+    } else if (signal in os.constants.signals) {
       try {
         pty.kill(this._fd, os.constants.signals[signal]);
       } catch (e) { /* swallow */ }
-    }else{
+    } else {
       // Unknown signal
     }
   }


### PR DESCRIPTION
This patch changes the unix version of the .kill function to send the signal to all processes of the process group of the pts using the TIOCSIG or TIOCSIGNAL ioctl, except for the SIGHUP signal, for which the original behaviour is retained.

See #167 for details