### PR TITLE
Write flush callback

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -32,9 +32,14 @@ export interface ITerminal {
 
   /**
    * Writes data to the socket.
-   * @param data The data to write.
+   *
+   * Optional parameter `callback` will be called with `true` if the entire data was flushed successfully to the kernel buffer or called with `false` if all or part of the data was queued in user memory. 'drain' event will be emitted when the buffer is again free.
+   *
+   * @param data The data to write. If you want to simulate pressing the ENTER key, like when entering a command, finish the string with the character `'\r'`
+   *
+   * @param callback Function called with true or false as explained in the method description. Take in consideration that this listener could be called several times.
    */
-  write(data: string): void;
+  write(data: string, callback?: (flushed: boolean) => any): void;
 
   /**
    * Resize the pty.

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -31,16 +31,17 @@ describe('Terminal', () => {
   });
 
 
-  describe('write() basics',  () => {
+  describe('write basics',  () => {
+
     it('should emit "data"', (done) => {
-      const terminal: Terminal = newTerminal();
+      const terminal = newTerminal();
       let allTheData = '';
       terminal.on('data', (chunk) => {
         allTheData += chunk;
       });
       (<any>pollUntil)(() => {
         if (allTheData.indexOf('hello') !== -1 && allTheData.indexOf('world') !== -1) {
-          terminal.destroy();
+          // terminal.destroy();
           done();
           return true;
         }
@@ -51,12 +52,12 @@ describe('Terminal', () => {
     });
 
     it('should let us know if the entire data was flushed successfully to the kernel buffer or was queued in user memory and in the later case when it finish to be consumed', (done) => {
-      const shortString = 'ls\f';
+      const shortString = 'ls';
       const terminal = newTerminal();
       terminal.write(shortString, (flushed: boolean) => {
-          terminal.destroy();
           done && done(); // because we are notified several times and we want to call done once
           done = null;
+          // terminal.destroy();
       });
     });
   });
@@ -73,6 +74,7 @@ describe('Terminal', () => {
     let shouldEmitDrain = false;
     let drainEmitted = false;
 
+
     it('should provide meanings to know if the entire data was flushed successfully to the kernel buffer or was queued in user memory', (done) => {
       let longString = buildLongInput();
       const terminal = newTerminal();
@@ -83,7 +85,6 @@ describe('Terminal', () => {
       terminal.write(longString, (flushed: boolean) => {
         if (!flushedAlready && flushed) {
           flushedAlready = true;
-          terminal.destroy();
           done && done();
           done = null;
         }

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -5,6 +5,8 @@
 import * as assert from 'assert';
 import { WindowsTerminal } from './windowsTerminal';
 import { UnixTerminal } from './unixTerminal';
+import { Terminal } from './terminal';
+import pollUntil = require('pollUntil');
 
 let PlatformTerminal: WindowsTerminal | UnixTerminal;
 if (process.platform === 'win32') {
@@ -13,6 +15,12 @@ if (process.platform === 'win32') {
   PlatformTerminal = require('./unixTerminal');
 }
 
+let terminalWriteDescribe;
+function newTerminal(): Terminal {
+  return process.platform === 'win32' ? new WindowsTerminal() : new UnixTerminal();
+}
+
+
 describe('Terminal', () => {
   describe('constructor', () => {
     it('should do basic type checks', () => {
@@ -20,6 +28,87 @@ describe('Terminal', () => {
         () => new (<any>PlatformTerminal)('a', 'b', { 'name': {} }),
         'name must be a string (not a object)'
       );
+    });
+  });
+
+  describe('terminal write()', terminalWriteDescribe = () => {
+
+    it('should emit "data"', (done) => {
+      const terminal: Terminal = newTerminal();
+      let allTheData = '';
+      terminal.on('data', (chunk) => {
+        allTheData += chunk;
+      });
+      (<any>pollUntil)(() => {
+        if (allTheData.indexOf('hello') !== -1 && allTheData.indexOf('world') !== -1) {
+          terminal.destroy();
+          done();
+          return true;
+        }
+        return false;
+      });
+      terminal.write('hello');
+      terminal.write('world');
+    });
+
+    describe('write callback', () => {
+      let shortTime;
+      let longTime;
+      let shouldEmitDrain = false;
+      let drainEmitted = false;
+
+      it('should flush quickly short strings', (done) => {
+        const shortString = 'ls\f';
+        const terminal = newTerminal();
+        let flushedAlready = false;
+        shortTime = Date.now();
+        terminal.write(shortString, (flushed: boolean) => {
+          if (!flushedAlready && flushed) {
+            flushedAlready = true;
+            shortTime = Date.now() - shortTime;
+            terminal.destroy();
+            done && done();
+            done = null;
+          }
+        });
+      });
+
+      it('long strings should take longer', (done) => {
+        let longString = terminalWriteDescribe.toString() + '\f';
+        for (let i = 0; i < 3; i++) {
+          longString += longString;
+        }
+        const terminal = newTerminal();
+        terminal.on('drain', () => {
+          drainEmitted = true;
+        });
+        let flushedAlready = false;
+        longTime = Date.now();
+        terminal.write(longString, (flushed: boolean) => {
+          if (!flushedAlready && flushed) {
+            flushedAlready = true;
+            longTime = Date.now() - longTime;
+            console.log({longTime, shortTime});
+            terminal.destroy();
+            assert.ok(longTime > shortTime, 'inputs considerably bigger should take more time to flush');
+            done && done();
+            done = null;
+          }
+          else {
+            shouldEmitDrain = true;
+          }
+        });
+      }).timeout(4000);
+
+      it('should emit ""drain" event when data could not be flushed entirely', () => {
+        if (shouldEmitDrain) {
+          assert.ok(drainEmitted, '"drain" event should be emitted when input to write cannot be flushed entirely');
+        }
+        else {
+          assert.ok(!drainEmitted, '"drain" event shouldn\'t be emitted if write input was flushed entirely');
+        }
+      });
+
     });
   });
 });

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -15,7 +15,6 @@ if (process.platform === 'win32') {
   PlatformTerminal = require('./unixTerminal');
 }
 
-let terminalWriteDescribe;
 function newTerminal(): Terminal {
   return process.platform === 'win32' ? new WindowsTerminal() : new UnixTerminal();
 }
@@ -31,6 +30,7 @@ describe('Terminal', () => {
     });
   });
 
+  let terminalWriteDescribe;
   describe('terminal write()', terminalWriteDescribe = () => {
 
     it('should emit "data"', (done) => {
@@ -88,7 +88,6 @@ describe('Terminal', () => {
           if (!flushedAlready && flushed) {
             flushedAlready = true;
             longTime = Date.now() - longTime;
-            console.log({longTime, shortTime});
             terminal.destroy();
             assert.ok(longTime > shortTime, 'inputs considerably bigger should take more time to flush');
             done && done();

--- a/src/terminal.test.ts
+++ b/src/terminal.test.ts
@@ -30,8 +30,8 @@ describe('Terminal', () => {
     });
   });
 
-  describe('terminal write()',  () => {
 
+  describe('write() basics',  () => {
     it('should emit "data"', (done) => {
       const terminal: Terminal = newTerminal();
       let allTheData = '';
@@ -50,78 +50,59 @@ describe('Terminal', () => {
       terminal.write('world');
     });
 
-    describe('write() callback, input consumption and "drain" event', () => {
-    //   // let shortTime;
-    //   // let longTime;
+    it('should let us know if the entire data was flushed successfully to the kernel buffer or was queued in user memory and in the later case when it finish to be consumed', (done) => {
+      const shortString = 'ls\f';
+      const terminal = newTerminal();
+      terminal.write(shortString, (flushed: boolean) => {
+          terminal.destroy();
+          done && done(); // because we are notified several times and we want to call done once
+          done = null;
+      });
+    });
+  });
 
-    //   it('should notify if the was completely consumed', (done) => {
-    //     const shortString = 'echo 1\f';
-    //     terminal = newTerminal();
-    //     let flushedAlready = false;
-    //     // shortTime = Date.now();
-    //     terminal.write(shortString, (flushed: boolean) => {
-    //       if (!flushedAlready && flushed) {
-    //         flushedAlready = true;
-    //         // shortTime = Date.now() - shortTime;
-    //         terminal.destroy();
-    //         done && done();
-    //         done = null;
-    //       }
-    //     });
-    //   });
-
-      let terminalWriteDescribe;
-      function buildLongInput(): string {
-        const count = process.platform === 'win32' ? 8 : 4;
-        let s = terminalWriteDescribe.toString() + '\f';
-        for (let i = 0; i < count; i++) {
-          s += s;
-        }
-        return s;
+  describe('write() data flush and "drain" event', () => {
+    function buildLongInput(): string {
+      const count = process.platform === 'win32' ? 8 : 6;
+      let s = buildLongInput.toString() + '\f';
+      for (let i = 0; i < count; i++) {
+        s += s;
       }
-      let shouldEmitDrain = false;
-      let drainEmitted = false;
-      let terminal;
+      return s;
+    }
+    let shouldEmitDrain = false;
+    let drainEmitted = false;
 
-      it('should provide meanings to know if the entire data was flushed successfully to the kernel buffer or was queued in user memory', terminalWriteDescribe = (done) => {
-        let longString = buildLongInput();
-        terminal = newTerminal();
-        terminal.on('drain', () => {
-          drainEmitted = true;
-        });
-        let flushedAlready = false;
-        // longTime = Date.now();
-        terminal.write(longString, (flushed: boolean) => {
-          if (!flushedAlready && flushed) {
-            flushedAlready = true;
-            // longTime = Date.now() - longTime;
-            // assert.ok(longTime > shortTime, 'inputs considerably bigger should take more time to flush');
-            // terminal.destroy();// dont destroy the terminal not yet because it could still emit some events we are interested on
-            done && done();
-            done = null;
-          }
-          else {
-            shouldEmitDrain = true;
-          }
-        });
-      }).timeout(4000);
-
-      it('should emit "drain" event to know when the kernel buffer is free again', () => {
-        if (process.platform === 'win32') {
-          assert.ok(true, 'winpty doesn\'t support "drain" event');
-        }
-        else if (shouldEmitDrain) {
-          assert.ok(drainEmitted, '"drain" event should be emitted when input to write cannot be flushed entirely');
+    it('should provide meanings to know if the entire data was flushed successfully to the kernel buffer or was queued in user memory', (done) => {
+      let longString = buildLongInput();
+      const terminal = newTerminal();
+      terminal.on('drain', () => {
+        drainEmitted = true;
+      });
+      let flushedAlready = false;
+      terminal.write(longString, (flushed: boolean) => {
+        if (!flushedAlready && flushed) {
+          flushedAlready = true;
+          terminal.destroy();
+          done && done();
+          done = null;
         }
         else {
-          assert.ok(!drainEmitted, '"drain" event shouldn\'t be emitted if write input was flushed entirely');
+          shouldEmitDrain = true;
         }
       });
+    }).timeout(4000);
 
-      it('clean up', () => {
-        terminal.destroy();
-      });
-
+    it('should emit "drain" event to know when the kernel buffer is free again', () => {
+      if (process.platform === 'win32') {
+        assert.ok(true, 'winpty doesn\'t support "drain" event');
+      }
+      else if (shouldEmitDrain) {
+        assert.ok(drainEmitted, '"drain" event should be emitted when input to write cannot be flushed entirely');
+      }
+      else {
+        assert.ok(!drainEmitted, '"drain" event shouldn\'t be emitted if write input was flushed entirely');
+      }
     });
   });
 });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -117,7 +117,7 @@ export abstract class Terminal implements ITerminal {
     this._socket.once(eventName, listener);
   }
 
-  public abstract write(data: string): void;
+  public abstract write(data: string, callback?: (flushed: boolean) => any): void;
   public abstract resize(cols: number, rows: number): void;
   public abstract destroy(): void;
   public abstract kill(signal?: string): void;

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -215,8 +215,8 @@ export class UnixTerminal extends Terminal {
     return self;
   }
 
-  public write(data: string): void {
-    this._socket.write(data);
+  public write(data: string, callback?: (flushed: boolean) => any): void {
+    return callback ? callback(this._socket.write(data, () => callback(true))) : this._socket.write(data);
   }
 
   public destroy(): void {

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -132,9 +132,14 @@ export class WindowsTerminal extends Terminal {
    * Events
    */
 
-  public write(data: string): void {
+  public write(data: string, callback?: (flushed: boolean) => any): void {
     this._defer(() => {
-      this._agent.inSocket.write(data);
+      if (callback) {
+        callback(this._agent.inSocket.write(data, () => callback(true)));
+      }
+      else {
+        this._agent.inSocket.write(data);
+      }
     });
   }
 


### PR DESCRIPTION
I really needed access to socket.write() callback and return value so I added a little API. 

I tried to document it the best I could, I don't think it is backwards incompatible because it just add a new parameter to write(). Also I written some specs and test them in linux and windows. 

I see that your windows implementation is intrinsic asynchronous so I had to maintain. that. Since I know you want to support old node.js versions I tried to provide an API with callbacks, but I really think Promises are the way to go here. 

I would very like keep working on other aspects of this great library but before that I would love to hear your opinions regarding asynchronicity, do you think we could include some library / pollyfil in the project ? For example this dependency /poll-until/ is using babel's ... Or do you prefer to stick too callbacks ? 

Thanks